### PR TITLE
Auto release and deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+
+  release:
+    if: github.event.commits[0].author.name != 'Nomie Release Bot'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run vbuild
+    - run: npm run generate-zip
+    - id: clean_working_dir
+      run: |
+        git reset --hard
+        release_zip=$(git ls-files --others --exclude-standard | grep "nomie6-oss.*.zip")
+        cp $release_zip /tmp
+        git clean -f
+        echo "release_zip=/tmp/$(basename $release_zip)" >> $GITHUB_OUTPUT
+    - run: npm run release:patch -- --ci --github.release \
+        --git.pushRepo=https://${{secrets.RELEASE_TOKEN}}@github.com/open-nomie/nomie6-oss.git \
+        --github.assets=${{steps.clean_working_dir.outputs.release_zip}}
+      env:
+        GIT_COMMITTER_NAME: Nomie Release Bot
+        GIT_AUTHOR_NAME: Nomie Release Bot
+        GITHUB_TOKEN: ${{ github.token }}
+
+  publish:
+    if: github.event.commits[0].author.name != 'Nomie Release Bot'
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        curl -X POST \
+          -H "Authorization: Bearer ${{secrets.RELEASE_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/open-nomie/open-nomie.github.io/actions/workflows/deploy.yml/dispatches \
+          -d '{"ref": "master"}'
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Build & Test
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
... on merge to master.

This PR introduces a Github Action on pushes to master which:

 - automatically generates a patch release (updates package.json; creates a git commit)
 - builds the project, generates a zip and publishes a "Github release" with the zip as a release asset.
 - triggers the GitHub pages (open-nomie/open-nomie.github.io) repository to build the latest release and deploy it to the Github pages site (https://open-nomie.github.io/)

## Pre-requisites 

Since there are branch restrictions on the master branch that prevent commits being pushed directly there, this workflow requires a personal access token from a user with admin/owner access to this repository.

A personal access token with limited scopes can be created [here](https://github.com/settings/personal-access-tokens/new). Select the open-nomie/nomie6-oss and open-nomie.github.io repositories. Grant the token read/write permissions to the Contents resource and read/write permissions to the Actions resource (this allows triggering the action to deploy the Github Pages site). Generate the token and copy it.

Then, under repository settings -> security -> secrets and variables -> actions, create a new repository secret called RELEASE_TOKEN and use the personal access token as the value for the secret. This token can be used by GitHub actions in the repository to push the release commit and dispatch the deploy action, but the value is not revealed in the Actions command output.
