### PR TITLE
Fix: remove auto focus on what's up text area

### DIFF
--- a/src/domains/capture-log/capture-log.svelte
+++ b/src/domains/capture-log/capture-log.svelte
@@ -360,7 +360,6 @@
                 placeholder={isPopulated || isFocused ? Lang.t('general.whats-up', "What's up?") : ''}
                 disabled={saving || saved}
                 bind:this={textarea}
-                autofocus
                 on:input={monitorNoteChange}
                 on:keydown={methods.keyPress}
                 on:focus={() => {


### PR DESCRIPTION
Fixes https://github.com/open-nomie/nomie6-oss/issues/9

Prevents keyboard from popping up and screen scrolling when tracking multiple events on android.

# Testing

Tested on most recent versions of Android on iOS. Verified screen does not jump and keyboard does not appear when inserting multiple events ... it certainly makes it easier to insert multiple trackers serially. Also tested with "single tap" trackers.