### PR TITLE
feat: remove feature restrictions requiring awards

### DIFF
--- a/src/domains/board/boardActions.ts
+++ b/src/domains/board/boardActions.ts
@@ -106,7 +106,6 @@ export const createNewBoard = async () => {
 export const getAddContextButton = (board: UniboardType) => {
   return {
     title: Lang.t('general.new-context', ' Add New +Context'),
-    awardRequired: 'open-streak-1',
     icon: BookmarksOutline,
     async click() {
       await 200
@@ -418,7 +417,6 @@ export const getAddPersonButton = (board?: UniboardType) => {
   return {
     title: `${Lang.t('general.new-person', 'Add New @Person')}`,
     icon: PeopleOutline,
-    awardRequired: 'open-streak-1',
     async click() {
       await wait(300)
       addNewPerson()
@@ -471,7 +469,6 @@ export const browseLibraryButton = {
 /* Creating a new tab button. */
 export const newTabButton = {
   title: `${Lang.t('general.new-tab', 'Add New Tab')}`,
-  // awardRequired: 'open-streak-1',
   icon: TabsOutline,
   divider: true,
   async click() {


### PR DESCRIPTION
Addresses #18.

Currently, creating a context or person requires that you have earned the "1 day open streak" award first. This PR removes this restriction.