### PR TITLE
fix: active board doesn't always load

### DIFF
--- a/src/domains/board/Uniboard.svelte
+++ b/src/domains/board/Uniboard.svelte
@@ -192,7 +192,6 @@
     !lastActiveId.length &&
     swiper
   ) {
-    lastActiveId = $UniboardStore.activeId
     setActiveBoard($UniboardStore.activeId)
     initialBoardActived = true
   }


### PR DESCRIPTION
This fixes issue #29 (also mentioned in #25) where if the active board is not the first board, the board doesn't scroll into view and the trackables do not appear.

It also addresses another behaviour where the active board is reset to the first board on page load (a side effect of the on:index event when the swiper initially loads).