### PR TITLE
fix: save timeframe in widget editor

### DIFF
--- a/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
+++ b/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
@@ -83,7 +83,7 @@ import { PluginStore } from "../../../plugins/PluginStore";
   const saveWidget = async () => {
     try {
 
-      if(![...activeType.requires, ...activeType.optional].indexOf('timeframe')) {
+      if([...activeType.requires, ...activeType.optional].indexOf('timeframe') === -1) {
         editingWidget.timeRange = undefined;
       }
 


### PR DESCRIPTION
Addresses #22: currently widget editor always resets timeframe to Today on save.