### PR TITLE
chore/fix: release v6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nomie",
-  "version": "6.1",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nomie",
-      "version": "6.1",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "@composi/gestures": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomie",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "homepage": "https://github.com/open-nomie/nomie-oss",
   "bugs": {
     "url": "https://github.com/open-nomie/nomie-oss/issues",


### PR DESCRIPTION
I merged some PRs to master yesterday, without updating the version number in package.json.

As a result the version on open-nomie.github.io won't update properly, and/or breaks on page reload. Rolling a release should fix this.