### PR TITLE
fix: previous text overwriting capture field when using trackers

### DIFF
--- a/src/domains/capture-log/capture-log.svelte
+++ b/src/domains/capture-log/capture-log.svelte
@@ -178,11 +178,13 @@
     clearTimeout(clearMonitor)
     clearMonitor = setTimeout(() => {
       showCaptureTextarea = true
-      // Extract Tokens
-      // await wait(5)
-      const parsed: Array<Token> = extract.parse($ActiveLogStore.note)
-      // Calculate Score
-      $ActiveLogStore.score = ScoreNote($ActiveLogStore.note, new Date(), $TrackerStore)
+      let parsed: Array<Token>;
+      ActiveLogStore.update((s) => {
+        parsed = extract.parse(s.note)
+        // Calculate Score
+        s.score = ScoreNote(s.note, new Date(), $TrackerStore)
+        return s
+      });
       // Highligh any visuble tracker buttons
       highlightSelectedTrackers(parsed || [])
     }, 500)


### PR DESCRIPTION
Fixes #28 (I think)

This issue is intermittent and I have had a lot of trouble reproducing it consistently, but it usually happens after saving, and inserting trackers and clicking around a lot over the course of a few minutes. After a lot of tracing, I have identified the apparent source of the issue and I think this PR resolves it. 