### PR TITLE
feat: resumable timers

### DIFF
--- a/src/components/classic-button/classic-button.svelte
+++ b/src/components/classic-button/classic-button.svelte
@@ -116,7 +116,7 @@
     </Text>
     {#if tracker.started}
       <div class="center">
-        <Counter started={tracker.started} />
+        <Counter initialDuration={tracker.timeTracked} started={tracker.started} />
       </div>
     {/if}
   </button>

--- a/src/components/counter/counter.svelte
+++ b/src/components/counter/counter.svelte
@@ -3,6 +3,7 @@
   import { onMount } from 'svelte'
 
   export let started = undefined
+  export let initialDuration = 0
   export let lg = undefined
   export let className = ''
   export let color = 'var(--color-red)'
@@ -19,10 +20,10 @@
   const methods = {
     init() {
       setInterval(() => {
-        let ms = new Date().getTime() - started
+        let ms = initialDuration*1000 + new Date().getTime() - started
         value = methods.secondsToTime(methods.msToSecond(ms))
       }, 1000)
-      let ms = new Date().getTime() - started
+      let ms = initialDuration*1000 + new Date().getTime() - started
       value = methods.secondsToTime(methods.msToSecond(ms))
     },
     normalizeTime(time) {

--- a/src/domains/board/UniboardTrackableGrid.svelte
+++ b/src/domains/board/UniboardTrackableGrid.svelte
@@ -71,7 +71,7 @@
       >
         <div slot="subtitle">
           {#if trackable.tracker?.started}
-            <Counter started={trackable.tracker.started} color={trackable.tracker.color} />
+            <Counter initialDuration={trackable.tracker.timeTracked} started={trackable.tracker.started} color={trackable.tracker.color} />
           {/if}
         </div>
       </ShortcutButton>

--- a/src/domains/steak/StreakStore.ts
+++ b/src/domains/steak/StreakStore.ts
@@ -1,6 +1,5 @@
 import {
-  getTrackerInputAsString,
-  openTrackerInputModal,
+  getTrackerInputAsString
 } from '../tracker/input/TrackerInputStore'
 
 import type { ITrackables } from '../trackable/trackable-utils'
@@ -35,6 +34,7 @@ export const trackOnThisDay = async (trackable: Trackable, date: Date, known: IT
           allowSave: false,
           expandNote: true,
           nextLabel: `Add to ${dayjs(date).format(dateFormats.tinyDate)} →`,
+          retrospective: true,
           // onClose: closeModal,
         })
         log.note = response.raw;

--- a/src/domains/tracker/TrackerStore.ts
+++ b/src/domains/tracker/TrackerStore.ts
@@ -25,14 +25,23 @@ export const TrackerStore = createKVStore(NPaths.storage.trackers(), {
  * @param ss
  * @returns Promise<TrackerClass>
  */
-const startStopTimer = async (tracker: TrackerClass, ss: 'start' | 'stop'): Promise<TrackerClass> => {
-  const newTracker = new TrackerClass(tracker)
-  if (ss == 'stop') {
-    newTracker.started = undefined
-  } else {
-    newTracker.started = new Date().getTime()
-  }
+const startStopTimer = async (tracker: TrackerClass, ss: 'start' | 'stop' | 'reset'): Promise<TrackerClass> => {
+  let newTracker;
   await TrackerStore.updateSync((trackerMap) => {
+    newTracker = new TrackerClass(trackerMap[tracker.tag])
+    switch (ss) {
+      case 'start':
+        newTracker.started = new Date().getTime()
+        break
+      case 'stop':
+        newTracker.timeTracked = trackerMap[tracker.tag].timeTracked + (new Date().getTime() - trackerMap[tracker.tag].started)/1000
+        newTracker.started = undefined
+        break
+      case 'reset':
+        newTracker.timeTracked = 0
+        newTracker.started = undefined
+        break
+    }
     trackerMap[tracker.tag] = newTracker
     return trackerMap
   })
@@ -57,6 +66,15 @@ export const startTimer = async (tracker: TrackerClass): Promise<TrackerClass> =
  */
 export const stopTimer = async (tracker): Promise<TrackerClass> => {
   return await startStopTimer(tracker, 'stop')
+}
+
+/**
+ * Clear a Timer
+ * @param tracker
+ * @returns Promise<TrackerClass>
+ */
+export const resetTimer = async (tracker): Promise<TrackerClass> => {
+  return await startStopTimer(tracker, 'reset')
 }
 
 /**

--- a/src/domains/tracker/input/TrackerInputStore.ts
+++ b/src/domains/tracker/input/TrackerInputStore.ts
@@ -25,6 +25,7 @@ export type TrackerInputProps = {
   raw?: string
   suffix?: string
   action?: string
+  retrospective?: boolean
 }
 
 const initialState = {
@@ -259,6 +260,7 @@ export const getTrackerInputAsString = async (props: TrackerInputProps): Promise
         allowSave: props.allowSave,
         expandNote: props.expandNote,
         nextLabel: props.nextLabel,
+        retrospective: props.retrospective,
         onClose: closeModal,
       })
     }

--- a/src/domains/tracker/input/input-modal-footer.svelte
+++ b/src/domains/tracker/input/input-modal-footer.svelte
@@ -50,7 +50,7 @@
             >
               <IonIcon icon={StopSolid} size={32} className="text-white" />
             </button>
-          {:else if !tracker.started && !value}
+          {:else if !tracker.started && !tracker.timeTracked}
             <button
               aria-label="Start Timer"
               type="button"

--- a/src/domains/tracker/input/input-modal-footer.svelte
+++ b/src/domains/tracker/input/input-modal-footer.svelte
@@ -50,7 +50,7 @@
             >
               <IonIcon icon={StopSolid} size={32} className="text-white" />
             </button>
-          {:else if !tracker.started && !tracker.timeTracked}
+          {:else if !tracker.started && !value}
             <button
               aria-label="Start Timer"
               type="button"

--- a/src/domains/tracker/input/input-modal.svelte
+++ b/src/domains/tracker/input/input-modal.svelte
@@ -51,6 +51,7 @@
   export let nextLabel = Lang.t('general.next', 'Next') // The label of the save Button
 
   let tracker: TrackerClass | undefined = undefined
+  let manual: boolean = false
 
   export let id: string
   export let payload: TrackerInputProps
@@ -144,6 +145,11 @@
     } else {
       data.value = tracker.default || 0
     }
+
+    if (payload.retrospective) {
+      manual = true
+    }
+
     setTimeout(() => {
       data.ready = true
     }, 12)
@@ -232,6 +238,7 @@
             >
               <NTimer
                 {tracker}
+                {manual}
                 value={data.value}
                 on:forceStart={methods.startTimer}
                 on:change={async (event) => {

--- a/src/domains/tracker/input/input-modal.svelte
+++ b/src/domains/tracker/input/input-modal.svelte
@@ -232,11 +232,11 @@
             >
               <NTimer
                 {tracker}
-                bind:value={data.value}
+                value={data.value}
                 on:forceStart={methods.startTimer}
                 on:change={async (event) => {
                   data.value = event.detail
-                  tracker = await resetTimer(tracker)
+                  tracker = await resetTimer(tracker, event.detail)
                 }}
               />
             </div>

--- a/src/domains/tracker/input/input-modal.svelte
+++ b/src/domains/tracker/input/input-modal.svelte
@@ -29,8 +29,6 @@
   import { Lang } from '../../../store/lang'
 
   import Button from '../../../components/button/button.svelte'
-  import dayjs from 'dayjs'
-
   import ToolbarGrid from '../../../components/toolbar/toolbar-grid.svelte'
   import type { TrackerInputProps } from './TrackerInputStore'
   import type TrackerClass from '../../../modules/tracker/TrackerClass'
@@ -41,13 +39,12 @@
 
   import KeyDown from '../../../modules/keyDown/keyDown.svelte'
   import { openTrackableEditor } from '../../trackable/trackable-editor/TrackableEditorStore'
-  import { startTimer, stopTimer } from '../TrackerStore'
+  import { startTimer, stopTimer, resetTimer } from '../TrackerStore'
   import BackdropModal from '../../../components/backdrop/backdrop-modal.svelte'
   import { closeModal } from '../../../components/backdrop/BackdropStore2'
   import type { TrackerInputResponseType } from './tracker-input-utils'
 
   // Props
-  // export let tracker = ; // You can provide a tracker
   export let value = undefined // If a valid is provided
 
   export let saveLabel = Lang.t('general.save', 'Save') // The label of the save Button
@@ -64,7 +61,6 @@
 
   let data = {
     value: null, // holds current value
-    tracker: null, // holds current tracker
     ready: false,
     suffix: '',
     calcUsed: false, // when it's ready
@@ -73,7 +69,7 @@
     note: undefined as undefined | string,
   }
 
-  // Set up the Methodsx
+  // Set up the Methods
   const methods = {
     // When the Save is hit
     onSave() {
@@ -88,6 +84,7 @@
           note: `#${tracker.tag}${data.value ? `(${data.value})` : ``} ${tracker.getIncluded(data.value)}`.trim(),
         }
         // dispatch('save', results)
+        resetTimer(tracker)
         payload.onComplete(results)
         closeModal(id)
         data.saving = false
@@ -96,6 +93,7 @@
     // When Add is hit
     onAdd() {
       // Dispatch add
+      resetTimer(tracker)
       payload.onComplete({
         value: data.value,
         action: 'add',
@@ -106,56 +104,25 @@
       closeModal(id)
     },
     async onCancel() {
+      if (tracker.type === 'timer' && !tracker.started) {
+        await resetTimer(tracker)
+      }
       closeModal(id)
-      // $Interact.trackerInput.show = false;
-      // if (!$Interact.trackerInput.allowSave) {
-      //   dispatch("cancelAll");
-      // } else {
-      //   dispatch("cancel");
-      // }
     },
     // When the user starts the time
-    startTimer() {
-      // Set the date to epoch time (best to avoid timezones);
-      let startingDate = dayjs().subtract(data.value, 'second')
-      data.tracker.started = startingDate.toDate().getTime()
+    async startTimer() {
       // Start the Timer for this tracker
-      startTimer(data.tracker)
+      tracker = await startTimer(tracker)
       methods.onCancel()
     },
     // Stop the Timer
-    stopTimer() {
+    async stopTimer() {
       // Get the Seconds between now and when the tracker started
-      if (data.tracker.started) {
-        data.value = (new Date().getTime() - tracker.started) / 1000
-        // Clear local
-        data.tracker.started = undefined
-        // tell store to stop timer
-        stopTimer(data.tracker)
-        tracker.started = undefined
+      if (tracker.started) {
+        tracker = await stopTimer(tracker)
+        data.value = tracker.timeTracked
       }
     },
-  }
-
-  // If Tracker Changes
-  // FIres each time something happens to this object
-  $: if (tracker && data.tracker && data.tracker !== tracker) {
-    // Set to local variable
-    setTimeout(() => {
-      // Set to not ready and the new tracker
-      data.ready = true // TODO: make this lack janky
-      data.tracker = tracker
-      data.value = tracker.default || 0
-      data.ready = true
-      data.suffix = ''
-    }, 1)
-  }
-
-  $: if (!payload.tracker) {
-    data.ready = true // TODO: make this lack janky
-    data.tracker = tracker
-    data.value = 0
-    data.suffix = ''
   }
 
   function editTracker() {
@@ -176,20 +143,13 @@
       data.value = value
     } else {
       data.value = tracker.default || 0
-      value = data.value
     }
-    data.tracker = tracker
     setTimeout(() => {
       data.ready = true
     }, 12)
   }
 
-  let lastTracker: TrackerClass | undefined = undefined
-  $: if (payload.tracker && lastTracker !== payload.tracker) {
-    lastTracker = payload.tracker
-    data.suffix = ''
-    initialize()
-  }
+  initialize();
 </script>
 
 <BackdropModal className="tracker-input-modal">
@@ -257,14 +217,12 @@
             />
           {:else if tracker.type === 'value' || tracker.type === 'tick'}
             <NCalculator
-              {value}
+              value={data.value}
               displayFormat={(input) => {
                 return tracker.displayValue(input || '')
               }}
               on:change={(changedValue) => {
                 data.value = changedValue.detail
-                value = changedValue.detail
-                data = data
               }}
             />
           {:else if tracker.type === 'timer'}
@@ -273,12 +231,12 @@
               class="filler flex items-center justify-center"
             >
               <NTimer
-                tracker={data.tracker}
+                {tracker}
                 bind:value={data.value}
                 on:forceStart={methods.startTimer}
-                on:change={(event) => {
+                on:change={async (event) => {
                   data.value = event.detail
-                  value = event.detail
+                  tracker = await resetTimer(tracker)
                 }}
               />
             </div>
@@ -291,7 +249,6 @@
                 }}
                 on:change={(value) => {
                   data.value = value.detail
-                  value = value.detail
                 }}
               />
             </div>

--- a/src/domains/tracker/input/timer.svelte
+++ b/src/domains/tracker/input/timer.svelte
@@ -24,10 +24,11 @@
   // Props
   export let value: number
   export let tracker: TrackerClass
+  export let manual: boolean = false
 </script>
 
 <div class="n-timer-input w-full">
-  {#if tracker.started}
+  {#if !manual && tracker.started}
     <div class="flex flex-col items-center justify-center">
       <div class="filler" />
       <Counter initialDuration={tracker.timeTracked} started={tracker.started} lg className="py-5 bg-light" />
@@ -43,7 +44,7 @@
           dispatch('change', event.detail)
         }}
       />
-      {#if !tracker.started && value}
+      {#if !manual && value}
         <button
           aria-label="Resume Timer"
           on:click={() => {

--- a/src/domains/tracker/input/timer.svelte
+++ b/src/domains/tracker/input/timer.svelte
@@ -7,12 +7,12 @@
    */
 
   // svelte
-  import { onMount } from 'svelte'
   import { createEventDispatcher } from 'svelte'
 
   // Components
   import Counter from '../../../components/counter/counter.svelte'
   import ManualTime from '../../../components/counter/manual-time.svelte'
+  import type TrackerClass from '../../../modules/tracker/TrackerClass'
 
   // Stores
 
@@ -22,19 +22,8 @@
   const dispatch = createEventDispatcher()
 
   // Props
-  export let value
-  export let tracker: any
-
-  // Data
-  let data = {
-    tempValue: (value || '') + '' || '',
-    changed: false,
-    started: tracker.started,
-  }
-
-  onMount(() => {
-    data.tempValue = value
-  })
+  export let value: number
+  export let tracker: TrackerClass
 </script>
 
 <div class="n-timer-input w-full">
@@ -54,7 +43,7 @@
           dispatch('change', event.detail)
         }}
       />
-      {#if !tracker.started && tracker.timeTracked}
+      {#if !tracker.started && value}
         <button
           aria-label="Resume Timer"
           on:click={() => {

--- a/src/domains/tracker/input/timer.svelte
+++ b/src/domains/tracker/input/timer.svelte
@@ -41,7 +41,7 @@
   {#if tracker.started}
     <div class="flex flex-col items-center justify-center">
       <div class="filler" />
-      <Counter started={tracker.started} lg className="py-5 bg-light" on:change={(event) => {}} />
+      <Counter initialDuration={tracker.timeTracked} started={tracker.started} lg className="py-5 bg-light" />
       <div class="filler" />
     </div>
   {:else}
@@ -54,9 +54,9 @@
           dispatch('change', event.detail)
         }}
       />
-      {#if !tracker.started && value}
+      {#if !tracker.started && tracker.timeTracked}
         <button
-          aria-label="Start Timer"
+          aria-label="Resume Timer"
           on:click={() => {
             dispatch('forceStart')
           }}

--- a/src/domains/tracker/timers/timers-modal.svelte
+++ b/src/domains/tracker/timers/timers-modal.svelte
@@ -43,7 +43,7 @@
         >
           <TrackableAvatar {trackable} slot="left" />
           <h1 class="ntitle py-3">{trackable.label}</h1>
-          <Counter slot="right" started={trackable.tracker.started} color={trackable.tracker.color} />
+          <Counter slot="right" initialDuration={trackable.tracker.timeTracked} started={trackable.tracker.started} color={trackable.tracker.color} />
         </ListItem>
         {#if index < trackables.length - 1}
           <Divider center />

--- a/src/modules/tracker/TrackerClass.ts
+++ b/src/modules/tracker/TrackerClass.ts
@@ -49,6 +49,7 @@ export type ITracker = {
   note?: string // Content to include when a note tracker
   hidden?: boolean // Hidden from All Board
   started?: number // If its started (and a timer based tracker)
+  timeTracked?: number
   picks?: Array<string> // Picks for a Picker type of tracker
   focus?: Array<IFocusUnit>
 }
@@ -78,6 +79,7 @@ export default class TrackerClass {
   public note?: string // Content to include when a note tracker
   public hidden?: boolean // Hidden from All Board
   public started?: number // If its started (and a timer based tracker)
+  public timeTracked?: number // amount of time previously tracker if paused (and a timer based tracker)
   public picks?: Array<string> // Picks for a Picker type of tracker
   public _dirty?: boolean
   public focus?: Array<IFocusUnit>
@@ -142,6 +144,7 @@ export default class TrackerClass {
     // If it's a timer, set if started else null
     if (this.type === 'timer') {
       this.started = starter.started
+      this.timeTracked = starter.timeTracked || 0
     }
 
     this.picks = starter.picks || undefined


### PR DESCRIPTION
Addresses #38.

Currently, timers reset and start counting from 0 when the user taps "Resume Timer". This PR adds a "timeTracked" property to timers, to keep track of total time tracked when the user pauses a timer, and adds it on when they resume the timer.

Also includes some refactoring of input-modal (which is used when choosing a value for any type of tracker).

# Testing

## Timers:

 - Start a timer. Pause the timer, resume the timer. It should resume counting.
 - Timer should show the correct time while it is tracking on the board and in running timers (clock icon in top left while timers are running).
 - Saving or adding should save or add the trackable value to the note and reset the timer.
 - Closing the modal while the timer is stopped (not tapping save or insert) should reset the timer.
 - Try having multiple timer trackers running at the same time. They should both count and resume correctly.

## Regression testing:

 - Try tracking with all the other types of trackers.
 - For value type trackers, make sure the calculator still works as expected.
 - Make sure default values and "Also include" work as expected.
 - Tap the triple dot on a tracker and add a value on a different day.
