### PR TITLE
fix: fetch and cache location on app startup

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,6 +56,7 @@
   import PluginLoader from './domains/plugins/plugin-loader.svelte'
   import { PluginStore } from './domains/plugins/PluginStore'
   import Setup from './domains/setup/setup.svelte'
+  import locate from './modules/locate/locate'
 
   // initiailze gestures
   gestures()
@@ -157,6 +158,16 @@
     wait(200).then(() => {
       hideSplashScreen()
     })
+
+    /**
+     * Fetch location onload if configured
+     * This caches a location to speed up Log creation on some mobile devices
+     */
+    if ($Prefs.alwaysLocate) {
+      // Get the Location
+      locate().catch((e) => console.warn('Error fetching initial onload location', e))
+    }
+
     Storage.init().then(async () => {
       // await initGoals()
       wait(2000).then(() => {


### PR DESCRIPTION
Discussed in #12.

> It's been working well for the most part. Sometimes (maybe 1 in 20) the location isn't fetched on load so I end up waiting the full 9 second timeout I configured like before. Still an improvement though.

I don't see the downside to this implementation, even if a device can fetch its location relatively quickly this should make the first (and every) Log instant. 