### PR TITLE
feat: keep capture log input visible when switching tabs

### DIFF
--- a/src/domains/capture-log/capture-log.css
+++ b/src/domains/capture-log/capture-log.css
@@ -191,7 +191,6 @@
   /* @apply border; */
   /* @apply border-gray-200 dark:border-gray-700; */
   @apply border-opacity-60;
-  transition: all 0.2s ease-in-out;
 }
 
 

--- a/src/domains/capture-log/capture-log.svelte
+++ b/src/domains/capture-log/capture-log.svelte
@@ -353,31 +353,24 @@
             data-placeholder={Lang.t('general.whats-up', "What's up?")}
             class=" mask-textarea-wrapper  top-section mock-textarea"
           >
-            {#if showCaptureTextarea}
-              <CaptureTextarea
-                bind:value={$ActiveLogStore.note}
-                aria-label="Note entry field"
-                id="textarea-capture-note"
-                class="overflow-y-scroll"
-                placeholder={isPopulated || isFocused ? Lang.t('general.whats-up', "What's up?") : ''}
-                disabled={saving || saved}
-                bind:this={textarea}
-                on:input={monitorNoteChange}
-                on:keydown={methods.keyPress}
-                on:focus={() => {
-                  setFocused()
-                }}
-                on:blur={() => {
-                  // isFocused = false
-                }}
-                on:paste={methods.keyPress}
-              />
-            {:else}
-              <!-- For Accessibility -->
-              <textarea aria-label="Note entry field" class=" w-full rounded-full" on:focus={() => setFocused()} />
-            {/if}
-
-            <!-- Close Note-->
+            <CaptureTextarea
+              bind:value={$ActiveLogStore.note}
+              aria-label="Note entry field"
+              id="textarea-capture-note"
+              class="overflow-y-scroll"
+              placeholder={isPopulated || isFocused ? Lang.t('general.whats-up', "What's up?") : ''}
+              disabled={saving || saved}
+              bind:this={textarea}
+              on:input={monitorNoteChange}
+              on:keydown={methods.keyPress}
+              on:focus={() => {
+                setFocused()
+              }}
+              on:blur={() => {
+                // isFocused = false
+              }}
+              on:paste={methods.keyPress}
+            />
           </div>
 
           <!-- Toolbar for advanced options -->

--- a/src/domains/capture-log/capture-textarea.svelte
+++ b/src/domains/capture-log/capture-textarea.svelte
@@ -16,14 +16,12 @@
 
   let textarea: any
   export let value: string
-  export let autofocus: boolean
   export let id: string
   const emit = createEventDispatcher()
 </script>
 
 <Textarea
   aria-label="Note entry field"
-  {autofocus}
   {id}
   on:inserted={async (evt) => {
     const tag = evt.detail.item.original.key


### PR DESCRIPTION
Addresses #37.

On desktop, it is possible to switch tabs while the capture log input is populated [not possible on mobile, because the tabs are obscured by the input, user must save or cancel first].

This PR makes it so that the content in the capture log input remains visible when the user switches tabs.