### PR TITLE
fix: fixes a particular case where the tracking board doesn't load after initial onboarding

### DIFF
--- a/src/domains/board/UniboardStore.ts
+++ b/src/domains/board/UniboardStore.ts
@@ -222,7 +222,6 @@ export const initUniboardStore = async (knownTrackables: ITrackables) => {
   // TODO: Handle Sorting
   UniboardStore.update((s) => {
     s.boards = boards
-    s.activeId = s.activeId || boards.length ? boards[0].id : undefined
     s.hash = objectHash(boards)
 
     s.dynamicBoards.people = {
@@ -244,8 +243,13 @@ export const initUniboardStore = async (knownTrackables: ITrackables) => {
       elements: trackables.filter((t) => t.type === 'tracker').map((t) => t.tag),
     }
 
+    if (s.boards.find((b) => b.id == getLastBoardId())) {
+      s.activeId = getLastBoardId()
+    } else {
+      s.activeId = boards.length ? boards[0].id : undefined
+    }
     s.loaded = true
-    s.activeId = getLastBoardId()
+
     return s
   })
 }


### PR DESCRIPTION
Fixes #40.

To reproduce this bug, destroy all data and go through onboarding without selecting any templates or trackers. On the empty "Track" tab, tap "Browse Library", select a template and "Use this template". The trackers you added do not appear and we see 6 placeholders instead.

The bug should be fixed and not reproducible in this branch.