### PR TITLE
47 different widgets for single plugin

### DIFF
--- a/src/domains/dashboard2/widget/types/widget-plugin.svelte
+++ b/src/domains/dashboard2/widget/types/widget-plugin.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import { Lang } from '../../../../store/lang'
 
-  import type { TrackableUsage } from '../../../usage/trackable-usage.class'
-  // import type { Trackable } from '../../../trackable/Trackable.class'
   import type { WidgetClass } from '../widget-class'
   import { PluginStore } from '../../../plugins/PluginStore'
   import type { PluginClass } from '../../../plugins/plugin-helpers'
@@ -10,13 +7,17 @@
   export let widget: WidgetClass
   // export let trackable: Trackable
   let plugin: PluginClass
+  let widgetindexparam: string =  "";
   $: if (widget && widget.data?.pluginId) {
-    plugin = $PluginStore.find((p) => p.id == widget.data.pluginId && p.active == true)
+      if (widget.data.widgetindex){
+        widgetindexparam = '&widgetindex='+widget.data.widgetindex;
+      }
+      plugin = $PluginStore.find((p) => p.id == widget.data.pluginId && p.active == true)
   }
 </script>
 
 {#if plugin}
-  <PluginFrame lid="widget-{widget.id}" openAction="onWidget" {plugin} />
+  <PluginFrame lid="widget-{widget.id}" openAction="onWidget" {plugin} {widgetindexparam}/>
 {:else}
   <div class="w-full h-full flex text-xs text-gray-500 items-center justify-center">
     Plugin not found or disabled

--- a/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
+++ b/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
@@ -32,8 +32,9 @@
   import { isTruthy } from '../../../../utils/truthy/truthy'
   import { closeModal } from '../../../../components/backdrop/BackdropStore2'
   import BackdropModal from '../../../../components/backdrop/backdrop-modal.svelte'
-import CloseOutline from '../../../../n-icons/CloseOutline.svelte'
-import { PluginStore } from "../../../plugins/PluginStore";
+  import CloseOutline from '../../../../n-icons/CloseOutline.svelte'
+  import { PluginStore } from "../../../plugins/PluginStore";
+  import Storage from '../../../../domains/storage/storage'
 
   let visible: boolean = false
   let editingWidget: WidgetClass | undefined
@@ -57,6 +58,9 @@ import { PluginStore } from "../../../plugins/PluginStore";
 
   $: if (editingWidget.type) {
     activeType = widgetTypes.find((wt) => wt.id === editingWidget.type)
+    if (editingWidget.type == "plugin"){
+      pluginGetWidgets(editingWidget.data.pluginId);
+    }
   }
 
   let lastWidgetHash: string | undefined = undefined
@@ -68,6 +72,32 @@ import { PluginStore } from "../../../plugins/PluginStore";
       console.error(e)
       canSave = false
     }
+  }
+
+  let pluginWidgets = [];
+  async function pluginGetWidgets(pluginId:String) {
+    let path = `plugins/${pluginId}/prefs.json`
+    let data: any = undefined
+    try {
+      data = await Storage.get(path) || {widgets:[]};
+      pluginWidgets = data.widgets;
+      if (pluginWidgets == undefined || !validateWidgetParams(data.widgets)){pluginWidgets = [];}
+    } catch (e) {
+      console.error(e)
+      pluginWidgets = [];
+    }
+  }
+
+  function validateWidgetParams(widgets){
+    let valid = true;
+    let i = 0;
+    while (i < widgets.length) {
+    if (!widgets[i].emoji || !widgets[i].name || !widgets[i].widgetid || widgets[i].emoji =="" || widgets[i].name =="" || widgets[i].widgetid ==""){
+      valid = false;
+      }
+      i++;
+    }   
+    return valid;
   }
 
   const close = async () => {
@@ -212,6 +242,31 @@ import { PluginStore } from "../../../plugins/PluginStore";
         <Input listItem placeholder="Message" type="textarea" rows={2} bind:value={editingWidget.description} />
         <div class="text-gray-500 leading-tight px-4 text-sm pb-4">Leave yourself a positive message or something!</div>
       </List>
+    {/if}
+
+    <!-- Plugins -->
+    {#if activeType?.id == 'plugin'}
+    {#if pluginWidgets.length > 0}
+    <List solo className="mt-4">
+    <Input listItem bind:value={editingWidget.data.widgetindex} type="select" label="Widget">
+      <div
+        slot="left"
+        class="{!editingWidget.data.widgetindex
+          ? 'pl-2 pt-3 w-full'
+          : ''} text-black dark:text-white pointer-events-none absolute"
+      >
+        {#if !editingWidget.data.widgetindex}
+          Select a Widget
+        {/if}
+      </div>
+      {#each pluginWidgets as pluginWidget}
+        <option value={pluginWidget.widgetid}>{pluginWidget.emoji} {pluginWidget.name}</option>
+      {/each}
+    </Input>
+      
+        <div class="text-gray-500 leading-tight px-4 text-sm pb-4">Plugin widget selection placeholder</div>
+      </List>
+    {/if}
     {/if}
 
     <!-- Start Conditional Styling -->

--- a/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
+++ b/src/domains/dashboard2/widget/widget-editor/widget-editor-modal.svelte
@@ -264,7 +264,7 @@
       {/each}
     </Input>
       
-        <div class="text-gray-500 leading-tight px-4 text-sm pb-4">Plugin widget selection placeholder</div>
+        <div class="text-gray-500 leading-tight px-4 text-sm pb-4">Select your Widget for this Plugin</div>
       </List>
     {/if}
     {/if}

--- a/src/domains/plugins/plugin-frame.svelte
+++ b/src/domains/plugins/plugin-frame.svelte
@@ -8,6 +8,7 @@
 
   export let plugin: PluginClass
   export let openAction: PluginUseTypes = 'onUIOpened'
+  export let widgetindexparam: string = "";
   export let lid: string
 
   let registered: boolean = false
@@ -17,6 +18,7 @@
 
   $: if (registered && !ready && mounted) {
     ready = true
+    plugin.url 
     broadcastPluginMessage(
       {
         action: openAction,
@@ -72,6 +74,6 @@
   }}
   class="h-full w-full "
   title={plugin.name}
-  src={plugin.urlWithParams}
+  src={plugin.urlWithParams}{widgetindexparam}
   id="plugin-{lid}-{plugin.id}"
 />


### PR DESCRIPTION
Enhancement #47 

This enhancement will enable multiple different widgets for a single plugin.

For testing purposes I have created a Plugin with multiple widgets. It is a Wordcloud plugin which will let you add wordcloud widgets to the Nomie dashboard. Users can configure wordclouds via the plugin. Each wordcloud configuration will be available as a separate widget for this plugin.

How to test:

1. install the wordcloud plugin: [https://dailynomie.github.io/nomie-plugin-widget-wordcloud/ ](https://dailynomie.github.io/nomie-plugin-widget-wordcloud/) 
2. open the plugin once to have it initialized 
3. exit the plugin
4. Go to the Nomie dashboard and click on add a widget => select the wordcloud widget. You will see a selection field, you can now select one of the widgets belonging to this plugin:

<img width="1034" alt="Screenshot 2023-02-11 at 23 13 48" src="https://user-images.githubusercontent.com/1215327/218283713-a9c8d092-d2bc-4d30-b551-ab62828b1bf7.png">


