### PR TITLE
Enhancement: 51 stats option for line bar charts

### DIFF
--- a/src/domains/dashboard2/widget/widget-display.svelte
+++ b/src/domains/dashboard2/widget/widget-display.svelte
@@ -21,7 +21,6 @@
   import { Lang } from '../../../store/lang'
   import { showToast } from '../../../components/toast/ToastStore'
   import { PluginStore } from "../../plugins/PluginStore";
-import WidgetBarChart from './types/widget-bar-chart.svelte';
 
   const dispatch = createEventDispatcher()
   const id = nid()

--- a/src/domains/ledger/LedgerStore.ts
+++ b/src/domains/ledger/LedgerStore.ts
@@ -680,6 +680,7 @@ export const queryToTrackableUsage = async (
   known: ITrackables
 ): Promise<TrackableUsage> => {
   const usages = await queryToUsageMap(query, known)
+  console.log(usages)
   return usages[trackable.tag] || new TrackableUsage({ trackable, dates: [], values: [] })
 }
 

--- a/src/domains/ledger/LedgerStore.ts
+++ b/src/domains/ledger/LedgerStore.ts
@@ -680,7 +680,6 @@ export const queryToTrackableUsage = async (
   known: ITrackables
 ): Promise<TrackableUsage> => {
   const usages = await queryToUsageMap(query, known)
-  console.log(usages)
   return usages[trackable.tag] || new TrackableUsage({ trackable, dates: [], values: [] })
 }
 

--- a/src/domains/usage/ChartOptionsStore.ts
+++ b/src/domains/usage/ChartOptionsStore.ts
@@ -3,6 +3,7 @@ import { writable } from 'svelte/store'
 type ChartOptions = {
   type: 'bar' | 'line'
   startWithZero: boolean
+  stats: 'none' | "avg" | 'sma-7' | 'sma-15' | 'sma-30' | 'ema-7' | 'ema-15' | 'ema-30' | 'split-11' | 'split-12' | 'split-13' | 'cumm'
 }
 export type ChartOptionsStoreState = {
   [key: string]: ChartOptions

--- a/src/domains/usage/ChartOptionsStore.ts
+++ b/src/domains/usage/ChartOptionsStore.ts
@@ -1,9 +1,11 @@
 import { writable } from 'svelte/store'
+import type { Trackable } from '../trackable/Trackable.class'
 
 type ChartOptions = {
   type: 'bar' | 'line'
   startWithZero: boolean
   stats: 'none' | "avg" | 'sma-7' | 'sma-15' | 'sma-30' | 'ema-7' | 'ema-15' | 'ema-30' | 'split-11' | 'split-12' | 'split-13' | 'cumm'
+  include: Trackable
 }
 export type ChartOptionsStoreState = {
   [key: string]: ChartOptions

--- a/src/domains/usage/usage-chart.svelte
+++ b/src/domains/usage/usage-chart.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import _ from "lodash"
   import type { ChartConfiguration, ChartDataset } from 'chart.js'
   import type { Dayjs } from 'dayjs'
   import { onMount } from 'svelte'
-
+  import usageStats from "./usage-stats";
   import Chartjs from '../../components/charts/chartjs.svelte'
   import { openDropMenu } from '../../components/menu/useDropmenu'
   import IonIcon from '../../components/icon/ion-icon.svelte'
@@ -10,10 +11,10 @@
   import Spinner from '../../components/spinner/spinner.svelte'
   import { hex2rgba } from '../../modules/colors/colors'
   import { Lang } from '../../store/lang'
-
+  import { LedgerStore } from '../ledger/LedgerStore'
   import { parseNumber } from '../../utils/parseNumber/parseNumber'
   import { wait } from '../../utils/tick/tick'
-
+  import logsToTrackableUsage, { logFilter } from '../usage/usage-utils'
   import { queryToTrackableUsage } from '../ledger/LedgerStore'
   import { getDateFormats } from '../preferences/Preferences'
   import { selectTrackable } from '../trackable/trackable-selector/TrackableSelectorStore'
@@ -22,10 +23,10 @@
   import { TrackableStore } from '../trackable/TrackableStore'
   import { saveChartOptions, getChartOption } from './ChartOptionsStore'
 
-  import type { TrackableUsage } from './trackable-usage.class'
+  import { TrackableUsage } from './trackable-usage.class'
   import { openDateOptionPopMenu, openPopMenu, PopMenuButton } from '../../components/pop-menu/usePopmenu'
-import Badge from '../../components/badge/badge.svelte'
-import CloseOutline from '../../n-icons/CloseOutline.svelte'
+  import CloseOutline from '../../n-icons/CloseOutline.svelte'
+  import { getAroundThisTimeDateRanges } from "../trending/TrendingModalStore"
 
   export let usages: Array<TrackableUsage> = []
   export let style: string = ''
@@ -39,6 +40,7 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
 
   let dateFormats = getDateFormats()
   let usage: TrackableUsage
+  let reverseUsage: TrackableUsage
 
   let activeDate: Dayjs | undefined = undefined
   let activeFormatedValue: string
@@ -54,31 +56,34 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
   let localType: 'bar' | 'line' = type
   let showChart: boolean = true
   let chartScale: 'linear' | 'logarithmic' = 'linear'
-
+  let chartStats: 'none' | "avg" | 'sma-7' | 'sma-15' | 'sma-30' | 'ema-7' | 'ema-15' | 'ema-30' | 'split-11' | 'split-12' | 'split-13' | 'cumm' = 'none'
   let startWithZero: boolean = true
 
-  const setChartType = async (type, swz, save: boolean = true) => {
+  const setChartType = async (type, swz, stats, save: boolean = true) => {
     showChart = false
     localType = type
     startWithZero = swz
+    chartStats = stats
     if (save) {
-      saveChartOptions(id, { type, startWithZero })
+      saveChartOptions(id, { type, startWithZero, stats})
     }
     await wait(60)
+    await includeStats()
     showChart = true
   }
 
-  const initChartOptions = () => {
+  const initChartOptions = async () => {
     let options: any = getChartOption(id) || {}
 
     let t = (options.type || type) == 'line' ? 'line' : 'bar'
     let swz = options.startWithZero === undefined || options.startWithZero === false ? false : true
-    setChartType(t, swz, false)
+    let st = options.stats || 'none'
+    setChartType(t, swz, st, false)
   }
 
   const alsoInclude = async () => {
-    const selected: Trackable = await selectTrackable()
-    const usage = await queryToTrackableUsage(
+   const selected: Trackable = await selectTrackable()
+   const usage :TrackableUsage = await queryToTrackableUsage(
       selected,
       {
         start: usages[0].dates[0],
@@ -86,9 +91,50 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
       },
       $TrackableStore.trackables
     )
-    usages.push(usage)
-
+   
+    if (usages[0].groupedBy == "week") {
+      reverseUsage = usage
+        .reverse()
+        .groupBy('week', 'YYYY-MM-D')
+        .backfill(usages[0].dates[0].toDate(), usages[0].dates[usages[0].dates.length - 1].toDate())
+    } else {
+      reverseUsage = usage
+        .reverse()
+        .byDay.backfill(usages[0].dates[0].toDate(), usages[0].dates[usages[0].dates.length - 1].toDate())
+    }
+   
+    // below is a strange bug => I need to push twice and slice again the last one. To be investigated
+    usages.push(reverseUsage)
+    usages.push(reverseUsage)
+    usages.slice(0, -1);
+    console.log(usages)
     return usage
+  }
+
+
+   
+
+  const includeStats = async () => {
+    //remove current stats data if exist
+    if (usages.length >1) {
+        usages.splice(_.findIndex(usages, function(item) {
+        return item.trackable.id === "-statistics-";
+        }), 1);
+    }
+    //define new if applicable
+    var statusage = usages.find(x=>x!==undefined);
+    if (chartStats != "none") {
+      if ((chartStats == "cumm" && statusage.trackable.tracker.math == "sum") || chartStats != "cumm") {
+        let datasetMain = statusage.values;
+        let statsTrackable = usageStats.defineStatsDataset(
+          datasetMain,
+          chartStats,
+          statusage.trackable.tracker.math,
+          usages[0]
+        );
+        usages.push(statsTrackable)
+      }
+    }
   }
 
   export const showOptionsMenu = async (caller: HTMLElement) => {
@@ -97,14 +143,14 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
         title: Lang.t('general.line-chart', 'Line Chart'),
         icon: localType === 'line' ? CheckmarkCircle : undefined,
         click() {
-          setChartType('line', startWithZero)
+          setChartType('line', startWithZero, chartStats)
         },
       },
       {
         title: Lang.t('general.bar-chart', 'Bar Chart'),
         icon: localType === 'bar' ? CheckmarkCircle : undefined,
         click() {
-          setChartType('bar', startWithZero)
+          setChartType('bar', startWithZero, chartStats)
         },
       },
       {
@@ -135,12 +181,154 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
         },
       },
       {
+        title: `Stats: ${chartStats}`,
+        divider: true,
+        click() {
+          const buttons: Array<PopMenuButton> = [
+            {
+              id: 'none',
+              title: 'No Stats',
+              checked: chartStats === 'none',
+              async click() {
+                chartStats = 'none'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'avg',
+              title: 'Average',
+              checked: chartStats === 'avg',
+              async click() {
+                chartStats = 'avg'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'split-11',
+              title: 'Average Split(50%-50%)',
+              checked: chartStats === 'split-11',
+              async click() {
+                chartStats = 'split-11'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'split-12',
+              title: 'Average Split(33%-66%)',
+              checked: chartStats === 'split-12',
+              async click() {
+                chartStats = 'split-12'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'split-13',
+              title: 'Average Split(25%-75%)',
+              checked: chartStats === 'split-13',
+              async click() {
+                chartStats = 'split-13'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'sma-7',
+              title: '7 days Simple Moving Average',
+              checked: chartStats === 'sma-7',
+              async click() {
+                chartStats = 'sma-7'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'sma-15',
+              title: '15 days Simple Moving Average',
+              checked: chartStats === 'sma-15',
+              async click() {
+                chartStats = 'sma-15'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'sma-30',
+              title: '30 days Simple Moving Average',
+              checked: chartStats === 'sma-30',
+              async click() {
+                chartStats = 'sma-30'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'ema-7',
+              title: '7 days Exponential Moving Average',
+              checked: chartStats === 'ema-7',
+              async click() {
+                chartStats = 'ema-7'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'ema-15',
+              title: '15 days Exponential Moving Average',
+              checked: chartStats === 'ema-15',
+              async click() {
+                chartStats = 'ema-15'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'ema-30',
+              title: '30 days Exponential Moving Average',
+              checked: chartStats === 'ema-30',
+              async click() {
+                chartStats = 'ema-30'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+            {
+              id: 'cumm',
+              title: 'Cummulative trend',
+              checked: chartStats === 'cumm',
+              async click() {
+                chartStats = 'cumm'
+                await wait(10)
+                await includeStats()
+                setChartType(localType, startWithZero, chartStats)
+              },
+            },
+
+          ]
+          openPopMenu({ id: 'chart-stats', buttons })
+        },
+      },
+      {
         title: Lang.t('general.start-with-zero', 'Start with Zero'),
         icon: startWithZero ? CheckmarkCircle : undefined,
         divider: true,
         click() {
           startWithZero = !startWithZero
-          setChartType(localType, startWithZero)
+          setChartType(localType, startWithZero, chartStats)
         },
       },
       {
@@ -149,7 +337,7 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
         async click() {
           await wait(10)
           await alsoInclude()
-          setChartType(localType, startWithZero)
+          setChartType(localType, startWithZero, chartStats)
         },
       },
     ]
@@ -165,9 +353,7 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
     const data = dates.map((date, index) => {
       return values[index]
     })
-
     let dataset: ChartDataset = {
-      type: localType,
       label: usageByDay.trackable.label,
       data,
     }
@@ -175,11 +361,12 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
     const skipped = (ctx, value) => (ctx.p0.skip || ctx.p1.skip ? value : undefined)
 
     // Setup Line of Bar differences
-    if (localType === 'line') {
+    if (localType === 'line' || usageByDay.trackable.id === "-statistics-") {
       //@ts-ignore
       dataset = {
         ...dataset,
         ...{
+          type: "line",
           pointRadius: 1,
           pointHitRadius: 10,
           borderColor: usageByDay.trackable.color,
@@ -199,6 +386,7 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
       dataset = {
         ...dataset,
         ...{
+          type: "bar",
           backgroundColor: usageByDay.trackable.color,
           barPercentage: 0.9,
           borderRadius: 100,
@@ -215,7 +403,6 @@ import CloseOutline from '../../n-icons/CloseOutline.svelte'
     const datasets = usages.map((usage) => {
       return usageToDataset(usage)
     })
-
     // Setup Config
     const config: ChartConfiguration = {
       type: localType,

--- a/src/domains/usage/usage-chart.svelte
+++ b/src/domains/usage/usage-chart.svelte
@@ -403,6 +403,14 @@
       data,
     }
 
+    // some visual adjustments if dataset is statistics dataset
+    var lineweight = 1.5;
+    var dotsweight = 1;
+    if (usageByDay.trackable.id === "-statistics-"){
+      lineweight = 2.5
+      dotsweight = 0
+    }
+
     const skipped = (ctx, value) => (ctx.p0.skip || ctx.p1.skip ? value : undefined)
 
     // Setup Line of Bar differences
@@ -412,12 +420,12 @@
         ...dataset,
         ...{
           type: "line",
-          pointRadius: 1,
+          pointRadius: dotsweight,
           pointHitRadius: 10,
           borderColor: usageByDay.trackable.color,
 
           spanGaps: true,
-          borderWidth: 1.5,
+          borderWidth: lineweight,
           backgroundColor: hex2rgba(usageByDay.trackable.color, 0.1),
           fill: 'origin',
           segment: {

--- a/src/domains/usage/usage-stats.ts
+++ b/src/domains/usage/usage-stats.ts
@@ -1,0 +1,167 @@
+import _ from "lodash";
+
+export default {
+
+    calculateCummulativeSum(nums) {
+        let cumm_array = [];
+        const cumulativeSum = (sum => value => sum += value)(0);
+        cumm_array = nums.map(cumulativeSum);
+        return cumm_array;
+    },
+    
+    
+     calculateSplitAverage(nums, splits) {
+        splits = String(splits);
+        let split1 = parseInt(splits.split('')[0]);
+        let split2 = parseInt(splits.split('')[1]);
+        let splittotal = split1 + split2;
+        let splitpercentage = (split1 / splittotal);
+        let arraylength = nums.length;
+        let array1 = [];
+        array1 = nums.slice(0, Math.round(((arraylength) * splitpercentage)));
+        let array2 = [];
+        array2 = nums.slice(Math.round((arraylength * splitpercentage)), arraylength);
+        let avg1 = array1.reduce((a, b) => a + b) / array1.length;
+        let avg1_array = array1.map(function () {
+            return avg1;
+        });
+
+        let avg2 = array2.reduce((a, b) => a + b) / array2.length;
+        let avg2_array = array2.map(function () {
+            return avg2;
+        });
+        avg2_array[0] = null; // set to create break in line
+        const splitavg_array = avg1_array.concat(avg2_array);
+
+        return splitavg_array;
+    },
+
+     calculateAverage(nums) {
+        let avg =  nums.reduce((a, b) => a + b) / nums.length;
+        let avg_array =  nums.map(function () {
+            return avg;
+        });
+        return avg_array;
+    },
+     calculateSimpleMovingAverage(nums, window = 5, n = Infinity) {
+        if (!nums || nums.length < window) {
+            return [];
+        }
+
+        let index = window - 1;
+        const length = nums.length + 1;
+        let indexinitial = 0;
+
+        const simpleMovingAverages = [];
+        let numberOfSMAsCalculated = 0;
+
+        //First we need to fill the first window, we do dat by starting with data point 0 and increase window until we reached target window
+        while (++indexinitial < window && numberOfSMAsCalculated++ < n) {
+            const initialwindowSlice = nums.slice(
+                indexinitial - indexinitial,
+                indexinitial
+            );
+            const initialsum = initialwindowSlice.reduce(
+                (prev, curr) => prev + curr,
+                0
+            );
+            simpleMovingAverages.push(initialsum / indexinitial);
+        }
+
+        while (++index < length && numberOfSMAsCalculated++ < n) {
+            const windowSlice = nums.slice(index - window, index);
+            const sum = windowSlice.reduce((prev, curr) => prev + curr, 0);
+            simpleMovingAverages.push(sum / window);
+        }
+
+        return simpleMovingAverages;
+    },
+     calculateExponentialMovingAverage(nums, window = 5) {
+        if (!nums || nums.length < window) {
+            return [];
+        }
+
+        let index = window - 1;
+        let indexinitial = 0;
+        let previousEmaIndex = 0;
+        const length = nums.length;
+        const smoothingFactor = 2 / (window + 1);
+
+        const exponentialMovingAverages = [];
+        const [sma] = this.calculateSimpleMovingAverage(nums, window, 1);
+        exponentialMovingAverages.push(sma);
+        //First we need to fill the first window, we do dat by starting with data point 0 and increase window until we reached target window
+        while (++indexinitial < window) {
+            const value = nums[indexinitial];
+            const previousEma = exponentialMovingAverages[previousEmaIndex++];
+            const currentEma = (value - previousEma) * smoothingFactor + previousEma;
+            exponentialMovingAverages.push(currentEma);
+        }
+
+        while (++index < length) {
+            const value = nums[index];
+            const previousEma = exponentialMovingAverages[previousEmaIndex++];
+            const currentEma = (value - previousEma) * smoothingFactor + previousEma;
+            exponentialMovingAverages.push(currentEma);
+        }
+
+        return exponentialMovingAverages;
+    },
+     validateData(data){
+        let datamean = _.mean(_.compact(data))
+        var validateddata =[];
+        for (var i = 0; i < data.length; i++) { 
+            if (Number.isNaN(data[i]) && !Number.isNaN(data[i+1])) {
+                validateddata[i]= data[i+1]
+                if (validateddata[i] == undefined) {validateddata[i] = datamean}
+            }
+        else if (Number.isNaN(data[i])){validateddata[i] = datamean}
+        else {validateddata[i] = data[i]}}
+        return validateddata
+    },
+     defineStatsDataset(datasetMain, showstats,math,source) {
+        //let maindata = datasetMain;
+        var maindata = this.validateData(datasetMain)
+        var data = [];
+        if (showstats == "avg") {
+            data=  this.calculateAverage(maindata)
+        }
+        if (showstats.includes("sma")) {
+            const window = parseInt(showstats.split("-")[1]);
+            data=  this.calculateSimpleMovingAverage(maindata, window)
+            }
+        if (showstats.includes("ema")) {
+            const window = parseInt(showstats.split("-")[1]);
+            data=  this.calculateExponentialMovingAverage(maindata, window)
+        }
+        if (showstats.includes("split")) {
+            const split = parseInt(showstats.split("-")[1]);
+            data=  this.calculateSplitAverage(maindata, split)
+        }
+        if (showstats.includes("cumm") && math == "sum") {
+            data=  this.calculateCummulativeSum(maindata)
+        }
+
+        let statsqueryresult = this.statsQuery(source,data)
+        return statsqueryresult;
+    },
+    statsQuery(source,data){
+        let result = {
+            "values":data,
+            "dates":source.dates,
+            "displayValue": source.displayValue,
+            "groupedBy": source.groupedBy,
+            "positivity": source.positivity,
+            "trackable": {
+                "id": "-statistics-",
+                "label":source.trackable.label +" stats",
+                "type":source.trackable.type,
+                "color":"#50B0EF",
+                "tracker": {
+                    "color":"#50B0EF"
+                }
+            }
+        }
+        return result
+    }
+};


### PR DESCRIPTION
Addressing #51 
.... and as a bonus fix the buggy Also Include and make the Also Include persistent

Testing:

**Statistics**
- go to the dashboard tab
- create a bar/line widget
- in the widget options (right bottom corner) choose Stats
- pick a specific statistic
=> the statistic should be visible as a blue line in the chart
- switch Nomie tabs or restart Nomie app
- go to the dashboard tab
=> the statistics should persist on the dashboard
- in the widget options (right bottom corner) choose Stats
- pick No Stats
=> the blue statistics line should be gone

**Also Include**
- go to the dashboard tab
- create a bar/line widget
- in the widget options (right bottom corner) choose Include
- in the next menu choose Select Trackable
- select the trackable you want to add to the widget
=> the other trackable should be visible in the widget chart
- switch Nomie tabs or restart Nomie app
- go to the dashboard tab
=> the statistics should persist on the dashboard
- in the widget options (right bottom corner) choose Include
- pick No Other Trackable
=> the other trackable should not be visible in the widget anymore