### PR TITLE
Fix: 56 dashboard editor widget delete

### DIFF
--- a/src/domains/dashboard2/dashbard-edit-view.svelte
+++ b/src/domains/dashboard2/dashbard-edit-view.svelte
@@ -17,6 +17,7 @@
   import SortableList2 from '../../components/sortable-list/sortable-list2.svelte'
   import TrackablePill from '../trackable/trackable-pill.svelte'
   import { PluginStore } from '../plugins/PluginStore'
+  import { deleteWidget } from './DashStore'
 
   export let dashboard: DashboardClass
 
@@ -38,9 +39,10 @@
   const removeWidget = async (widget) => {
     const confirmed = await Interact.confirm('Remove Widget?', 'You can always add it back later.')
     if (confirmed) {
-      workingDashboard.widgets = dedupArray(workingDashboard.widgets, 'id')
+      //workingDashboard.widgets = dedupArray(workingDashboard.widgets, 'id')
+     await deleteWidget(widget);
     }
-    workingDashboard.widgets = workingDashboard.widgets
+    workingDashboard.widgets = dashboard.widgets
   }
 
   onMount(() => {

--- a/src/domains/dashboard2/widget/types/widget-bar-chart.svelte
+++ b/src/domains/dashboard2/widget/types/widget-bar-chart.svelte
@@ -39,7 +39,7 @@
 {#if widget}
   <div class="chart-value relative h-full">
     <UsageChart
-      id={`usage-${nid(usage.trackable.tag)}`}
+      id={`usage-${nid(widget.id)}`}
       hideValues={widget.size == 'sm'}
       usages={[reverseUsage]}
       {type}


### PR DESCRIPTION
Fix for #56 

Test:
- Go to a dashboard
- click 'edit dashboard'
- in the editor, remove a widget by clicking on the red cross
- after confirmation the widget should disappear
- click on 'done'
- the widget should also be gone at the dashboard