### PR TITLE
Fix: 58 Timeframe bugs for last-7days & last week

### DIFF
--- a/src/domains/dashboard2/dashboard-widget-grid.svelte
+++ b/src/domains/dashboard2/dashboard-widget-grid.svelte
@@ -53,7 +53,7 @@
 
     // Set time frame
     let start = dashboard.timeframe.start
-    let end = dashboard.timeframe.end
+    let end = dashboard.timeframe.end.add(1, 'day') //add(1, 'day') is a fix for the extra day in the last week widget when Monday is first day of week
 
     // Get the Widgets
     widgets = dashboardWidgets.map((widget) => {

--- a/src/domains/dashboard2/widget/widget-timeframe.ts
+++ b/src/domains/dashboard2/widget/widget-timeframe.ts
@@ -88,7 +88,7 @@ export const timeFrames: Array<WidgetTimeFrameConfig> = [
     label: 'Last 7 days',
     dayCount: 7,
     start: {
-      subtract: [7, 'day'],
+      subtract: [6, 'day'],
       startOf: 'day',
     },
     end: {


### PR DESCRIPTION
Fix for issue #58 

### 1st bug, last 7 days line/bar chart is showing 8 days
**TEST:**
- add a bar/line chart widget to a dashboard with a timeframe of Last 7 Days
- the chart should only show the last 7 days (and not the last 8 days)

### 2nd bug, when selected week start is Monday and you have a single line/bar widget on the dashboard with a timeframe of Last Week, the last Sunday was not shown in the chart.
**TEST:**
- make sure that in 'settings' you have selected to start the week on Monday
- create an empty dashboard
- add a line/chart widget to this dashboard with a timeframe of Last Week
- the chart should show the values for all the days of last week, including the last Sunday
