### PR TITLE
feat: Service workers don't need to upgrade until 1 week

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 import NomieApp from './App.svelte'
 import { useRegisterSW } from 'virtual:pwa-register/svelte'
 
-const intervalMS = 60 * 60 * 1000
+const intervalMS = 60 * 60 * 1000 * 24 * 7; // 1 week
 
 /* It's registering a service worker and then updating it every hour. */
 useRegisterSW({


### PR DESCRIPTION
At the moment, pretty much whenever I load up Nomie on my phone I see a modal to update it, but it'll show up the next time as well, even if I try to upgrade it every time. See [issue and context here](https://github.com/open-nomie/nomie6-oss/issues/72). This change should fix this issue by elongating the Service Worker's upgrade interval to 1 week from 1 hour. 